### PR TITLE
Fixed PHP 8.2 deprecation warning: 'creation of dynamic property'.

### DIFF
--- a/library/Zend/Loader/Autoloader/Resource.php
+++ b/library/Zend/Loader/Autoloader/Resource.php
@@ -60,6 +60,11 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
     protected $_resourceTypes = array();
 
     /**
+     * @var array
+     */
+    protected $_resources = array();
+
+    /**
      * Constructor
      *
      * @param  array|Zend_Config $options Configuration options for resource autoloader


### PR DESCRIPTION
Fixes deprecation warning with PHP 8.2: `Creation of dynamic property xxx is deprecated`
I've used old PHP array syntax, just to stay consistent with the rest of the code.

Found with phpstan:
1. Have latest version of [phpstan](https://github.com/phpstan/phpstan) installed somewhere (I've used version 1.10.15)
2. Clone this repo
3. Inside the repo, run:
```
$ /path/to/phpstan analyse --level=0 . | grep 'Access to an undefined property'
```
4. Expected to see no errors, but seeing:
```
  468    Access to an undefined property Zend_Loader_Autoloader_Resource::$_resources.
```

PR fixes:
- missing member

This fixes one of the warnings mentioned in https://github.com/magento/adobe-commerce-beta/issues/61, If I find more time and this PR actually gets approved, I might try to tackle the others as well one day.